### PR TITLE
Secure cookies

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,19 +1,25 @@
 Changelog
 =========
 
+0.5.0 (2022-04-12)
+------------------
+
+* Add Secure=true flag to all cookies. This requires serving over HTTPS only,
+  but you should be doing that already if you care about security.
+
 0.4.0 (2022-02-03)
 ------------------
 
- * [Breaking change] ``fetch_user`` callback now takes two arguments: email
-   and token payload. This allows the clients to augment their User instances
-   with arbitrary data encoded in the token.
+* [Breaking change] ``fetch_user`` callback now takes two arguments: email
+  and token payload. This allows the clients to augment their User instances
+  with arbitrary data encoded in the token.
 
 0.3.0 (2022-01-10)
 ------------------
 
- * [Breaking change] ``get_token_from_request`` now returns ``Optional[Token]``.
-   This fixes a KeyError in ``AuthenticationService``, but it is technically
-   a breaking change since ``get_token_from_request`` could be used on its own.
+* [Breaking change] ``get_token_from_request`` now returns ``Optional[Token]``.
+  This fixes a KeyError in ``AuthenticationService``, but it is technically
+  a breaking change since ``get_token_from_request`` could be used on its own.
 
 0.2.0 (2021-12-28)
 ------------------

--- a/src/nameko_keycloak/service.py
+++ b/src/nameko_keycloak/service.py
@@ -126,22 +126,27 @@ class KeycloakSsoServiceMixin:
         response.set_cookie(
             key=f"{self.sso_cookie_prefix}_access-token",
             value=token_payload["access_token"],
+            secure=True,
         )
         response.set_cookie(
             key=f"{self.sso_cookie_prefix}_expires-in",
             value=str(token_payload["expires_in"]),
+            secure=True,
         )
         response.set_cookie(
             key=f"{self.sso_cookie_prefix}_refresh-token",
             value=token_payload["refresh_token"],
+            secure=True,
         )
         response.set_cookie(
             key=f"{self.sso_cookie_prefix}_refresh-expires-in",
             value=str(token_payload["refresh_expires_in"]),
+            secure=True,
         )
         response.set_cookie(
             key=f"{self.sso_cookie_prefix}_refresh-token-url",
             value=self.sso_refresh_token_url,
+            secure=True,
         )
         return response
 


### PR DESCRIPTION
Add Secure=true flag to all cookies. This requires serving over HTTPS only, but you should be doing that already if you care about security.