### PR TITLE
Silence invalid_grant errors

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ project = "nameko-keycloak"
 year = "2021"
 author = "Emplocity"
 copyright = "{0}, {1}".format(year, author)
-version = release = "2.0.0-alpha1"
+version = release = "2.0.0-alpha2"
 
 pygments_style = "trac"
 templates_path = ["."]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ project = "nameko-keycloak"
 year = "2021"
 author = "Emplocity"
 copyright = "{0}, {1}".format(year, author)
-version = release = "2.0.0-alpha2"
+version = release = "2.0.0-alpha3"
 
 pygments_style = "trac"
 templates_path = ["."]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "nameko-keycloak"
 description = "Helpers to integrate Single Sign-On in nameko-based applications using Keycloak."
-version = "2.0.0-alpha1"
+version = "2.0.0-alpha2"
 requires-python = ">=3.9"
 authors = [{name="Emplocity"}]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "nameko-keycloak"
 description = "Helpers to integrate Single Sign-On in nameko-based applications using Keycloak."
-version = "2.0.0-alpha2"
+version = "2.0.0-alpha3"
 requires-python = ">=3.9"
 authors = [{name="Emplocity"}]
 classifiers = [

--- a/src/nameko_keycloak/__init__.py
+++ b/src/nameko_keycloak/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "2.0.0-alpha1"
+__version__ = "2.0.0-alpha2"

--- a/src/nameko_keycloak/__init__.py
+++ b/src/nameko_keycloak/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "2.0.0-alpha2"
+__version__ = "2.0.0-alpha3"

--- a/src/nameko_keycloak/service.py
+++ b/src/nameko_keycloak/service.py
@@ -86,7 +86,19 @@ class KeycloakSsoServiceMixin:
 
         try:
             token_payload = self.keycloak.refresh_token(refresh_token=refresh_token)
-        except KeycloakError:
+        except KeycloakError as e:
+            # Decode Keycloak error details and decide if it's serious enough
+            # to call failure hook
+            error_code: str = ""
+            try:
+                payload = json.loads(e.response_body.decode("utf-8"))
+                error_code = payload["error"]
+            except Exception:
+                logger.exception("Failed to decode Keycloak error details")
+            if error_code == "invalid_grant":
+                # This is a normal situation, refresh token exists but expired.
+                # In this case frontend should redirect to login page.
+                logger.debug("Refresh token expired")
             self.run_hook(HookMethod.FAILURE)
             return Response("Invalid", status=401)
 

--- a/src/nameko_keycloak/service.py
+++ b/src/nameko_keycloak/service.py
@@ -99,7 +99,8 @@ class KeycloakSsoServiceMixin:
                 # This is a normal situation, refresh token exists but expired.
                 # In this case frontend should redirect to login page.
                 logger.debug("Refresh token expired")
-            self.run_hook(HookMethod.FAILURE)
+            else:
+                self.run_hook(HookMethod.FAILURE)
             return Response("Invalid", status=401)
 
         response = Response(


### PR DESCRIPTION
When refresh token expires, that's the best detail we can get from
Keycloak error. Any other case should still be handled by the failure
hook.